### PR TITLE
Add Sponsorblock Support

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -13,6 +13,7 @@ import {
 	VoiceServer,
 	WebSocketClosedEvent,
 } from "./Utils";
+import { SponsorBlockChaptersLoaded, SponsorBlockChapterStarted, SponsorBlockSegmentSkipped, SponsorBlockSegmentsLoaded } from "./Utils";
 import { Collection } from "@discordjs/collection";
 import { EventEmitter } from "events";
 import { Node, NodeOptions } from "./Node";
@@ -491,4 +492,8 @@ export interface ManagerEvents {
 	trackEnd: [player: Player, track: Track, payload: TrackEndEvent];
 	trackStuck: [player: Player, track: Track, payload: TrackStuckEvent];
 	trackError: [player: Player, track: Track | UnresolvedTrack, payload: TrackExceptionEvent];
+	SegmentsLoaded: [player: Player, track: Track | UnresolvedTrack, payload: SponsorBlockSegmentsLoaded];
+	SegmentSkipped: [player: Player, track: Track | UnresolvedTrack, payload: SponsorBlockSegmentSkipped];
+	ChapterStarted: [player: Player, track: Track | UnresolvedTrack, payload: SponsorBlockChapterStarted];
+	ChaptersLoaded: [player: Player, track: Track | UnresolvedTrack, payload: SponsorBlockChaptersLoaded];
 }

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -1,6 +1,6 @@
 import { Filters } from "./Filters";
 import { LavalinkResponse, Manager, PlaylistRawData, SearchQuery, SearchResult } from "./Manager";
-import { LavalinkInfo, Node } from "./Node";
+import { LavalinkInfo, Node, SponsorBlockSegment } from "./Node";
 import { Queue } from "./Queue";
 import { Sizes, State, Structure, TrackSourceName, TrackUtils, VoiceState } from "./Utils";
 import * as _ from "lodash";
@@ -383,6 +383,15 @@ export class Player {
 		this.volume = volume;
 
 		return this;
+	}
+	public async setSponsorBlock(segments: SponsorBlockSegment[] = ["sponsor", "selfpromo"]) {
+		return this.node.setSponsorBlock(this, segments);
+	}
+	public async getSponsorBlock() {
+		return this.node.getSponsorBlock(this);
+	}
+	public async deleteSponsorBlock() {
+		return this.node.deleteSponsorBlock(this);
 	}
 
 	/**

--- a/src/structures/Rest.ts
+++ b/src/structures/Rest.ts
@@ -59,7 +59,9 @@ export class Rest {
 			const response = await axios(config);
 			return response.data;
 		} catch (error) {
-			if (error?.response?.status === 404) {
+			if (error?.response.data.message === "Guild not found") {
+				return [];
+			} else if (error?.response?.status === 404) {
 				this.node.destroy();
 				this.node.manager.createNode(this.node.options).connect();
 			}
@@ -83,6 +85,10 @@ export class Rest {
 		return await this.request("POST", endpoint, body);
 	}
 
+	/* Sends a POST request to the specified endpoint and returns the response data. */
+	public async put(endpoint: string, body: unknown): Promise<unknown> {
+		return await this.request("PUT", endpoint, body);
+	}
 	/* Sends a DELETE request to the specified endpoint and returns the response data. */
 	public async delete(endpoint: string): Promise<unknown> {
 		return await this.request("DELETE", endpoint);

--- a/src/structures/Utils.ts
+++ b/src/structures/Utils.ts
@@ -229,9 +229,13 @@ export type LoadType = "track" | "playlist" | "search" | "empty" | "error";
 
 export type State = "CONNECTED" | "CONNECTING" | "DISCONNECTED" | "DISCONNECTING" | "DESTROYING";
 
-export type PlayerEvents = TrackStartEvent | TrackEndEvent | TrackStuckEvent | TrackExceptionEvent | WebSocketClosedEvent;
+export type SponsorBlockSegmentEvents = SponsorBlockSegmentSkipped | SponsorBlockSegmentsLoaded | SponsorBlockChapterStarted | SponsorBlockChaptersLoaded;
 
-export type PlayerEventType = "TrackStartEvent" | "TrackEndEvent" | "TrackExceptionEvent" | "TrackStuckEvent" | "WebSocketClosedEvent";
+export type SponsorBlockSegmentEventType = "SegmentSkipped" | "SegmentsLoaded" | "ChaptersLoaded" | "ChapterStarted";
+
+export type PlayerEvents = TrackStartEvent | TrackEndEvent | TrackStuckEvent | TrackExceptionEvent | WebSocketClosedEvent | SponsorBlockSegmentEvents;
+
+export type PlayerEventType = "TrackStartEvent" | "TrackEndEvent" | "TrackExceptionEvent" | "TrackStuckEvent" | "WebSocketClosedEvent" | "SegmentSkipped" | "SegmentsLoaded" | "ChaptersLoaded" | "ChapterStarted";
 
 export type TrackEndReason = "finished" | "loadFailed" | "stopped" | "replaced" | "cleanup";
 
@@ -337,6 +341,61 @@ export interface WebSocketClosedEvent extends PlayerEvent {
 	code: number;
 	reason: string;
 	byRemote: boolean;
+}
+
+export interface SponsorBlockSegmentsLoaded extends PlayerEvent {
+	type: "SegmentsLoaded";
+	/* The loaded segment(s) */
+	segments: {
+		/* The Category name */
+		category: string;
+		/* In Milliseconds */
+		start: number;
+		/* In Milliseconds */
+		end: number;
+	}[];
+}
+export interface SponsorBlockSegmentSkipped extends PlayerEvent {
+	type: "SegmentSkipped";
+	/* The skipped segment*/
+	segment: {
+		/* The Category name */
+		category: string;
+		/* In Milliseconds */
+		start: number;
+		/* In Milliseconds */
+		end: number;
+	};
+}
+
+export interface SponsorBlockChapterStarted extends PlayerEvent {
+	type: "ChapterStarted";
+	/** The Chapter which started */
+	chapter: {
+		/** The Name of the Chapter */
+		name: string;
+		/* In Milliseconds */
+		start: number;
+		/* In Milliseconds */
+		end: number;
+		/* In Milliseconds */
+		duration: number;
+	};
+}
+
+export interface SponsorBlockChaptersLoaded extends PlayerEvent {
+	type: "ChaptersLoaded";
+	/** All Chapters loaded */
+	chapters: {
+		/** The Name of the Chapter */
+		name: string;
+		/* In Milliseconds */
+		start: number;
+		/* In Milliseconds */
+		end: number;
+		/* In Milliseconds */
+		duration: number;
+	}[];
 }
 
 export interface PlayerUpdate {


### PR DESCRIPTION
Add Sponsorblock Support
supports node events
can set sponsorblock categories using 
await player.setSponsorBlock( ['sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'music_offtopic', 'filler']);

Added player.deleteSponsorBlock(), player.getSponsorBlock()

if you are merging this kindly check rest request function couldn't find better way to fix the GUILD NOT FOUND 404 error 
Thanks to Tomato6966 for his Lavalink-Client Repo

