### PR TITLE
Improvements in event reasons and accurate playlist information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 .nuxt
 .env
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 
 .nuxt
 .env
-/.idea/
+.idea

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -833,9 +833,26 @@ export interface PlaylistRawData {
 	tracks: TrackData[];
 }
 
+export interface PlaylistInfoData {
+	/** Url to playlist. */
+	url: string;
+	/** Type is always playlist in that case. */
+	type: string;
+	/** ArtworkUrl of playlist */
+	artworkUrl: string;
+	/** Number of total tracks in playlist */
+	totalTracks: number;
+	/** Author of playlist */
+	author: string;
+}
+
 export interface PlaylistData {
 	/** The playlist name. */
 	name: string;
+	/** Requester of playlist. */
+	requester: User | ClientUser;
+	/** More playlist information. */
+	playlistInfo: PlaylistInfoData[];
 	/** The length of the playlist. */
 	duration: number;
 	/** The songs of the playlist. */

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -476,6 +476,8 @@ export class Manager extends EventEmitter {
 			if (res.loadType === "playlist") {
 				playlist = {
 					name: playlistData!.info.name,
+					playlistInfo: playlistData.pluginInfo,
+					requester: requester,
 					tracks: playlistData!.tracks.map((track) => TrackUtils.build(track, requester)),
 					duration: playlistData!.tracks.reduce((acc, cur) => acc + (cur.info.length || 0), 0),
 				};

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -193,7 +193,7 @@ export class Player {
 		this.voiceChannel = channel;
 		this.connect();
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "channelChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "voiceChannelChange");
 		return this;
 	}
 
@@ -208,7 +208,7 @@ export class Player {
 
 		this.textChannel = channel;
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "channelChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "textChannelChange");
 		return this;
 	}
 
@@ -453,7 +453,7 @@ export class Player {
 			this.dynamicRepeat = false;
 		}
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "repeatChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackRepeatChange");
 		return this;
 	}
 
@@ -476,7 +476,7 @@ export class Player {
 			this.dynamicRepeat = false;
 		}
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "repeatChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "queueRepeatChange");
 		return this;
 	}
 
@@ -516,7 +516,7 @@ export class Player {
 			this.dynamicRepeat = false;
 		}
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "repeatChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "dynamicRepeatChange");
 		return this;
 	}
 
@@ -551,7 +551,7 @@ export class Player {
 			},
 		});
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChangeStop");
 		return this;
 	}
 
@@ -586,7 +586,7 @@ export class Player {
 		this.queue.unshift(this.queue.previous);
 		this.stop();
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChangePrevious");
 		return this;
 	}
 
@@ -614,7 +614,7 @@ export class Player {
 			},
 		});
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this, "trackChangeSeek");
 		return this;
 	}
 }

--- a/src/structures/Queue.ts
+++ b/src/structures/Queue.ts
@@ -85,7 +85,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 			}
 		}
 
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueTrackAdd");
 	}
 
 	/**
@@ -116,7 +116,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 
 			const removedTracks = this.splice(startOrPosition, end - startOrPosition);
 			this.manager.emit("debug", `[QUEUE] Removed ${removedTracks.length} track(s) from player: ${this.guild} from position ${startOrPosition} to ${end}.`);
-			this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+			this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueTrackRemove");
 
 			return;
 		}
@@ -124,7 +124,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 		// Single item removal when no end specified
 		const removedTrack = this.splice(startOrPosition, 1);
 		this.manager.emit("debug", `[QUEUE] Removed 1 track from player: ${this.guild} from position ${startOrPosition}: ${JSON.stringify(removedTrack[0], null, 2)}`);
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueTrackRemoveSingle");
 
 		return;
 	}
@@ -133,7 +133,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 	public clear(): void {
 		const oldPlayer = { ...this.manager.players.get(this.guild) };
 		this.splice(0);
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueClear");
 		this.manager.emit("debug", `[QUEUE] Cleared the queue for: ${this.guild}`);
 	}
 
@@ -144,7 +144,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 			const j = Math.floor(Math.random() * (i + 1));
 			[this[i], this[j]] = [this[j], this[i]];
 		}
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueShuffle");
 		this.manager.emit("debug", `[QUEUE] Shuffled the queue for: ${this.guild}`);
 	}
 
@@ -175,7 +175,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 
 		this.splice(0);
 		this.add(shuffledQueue);
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueUserBlockShuffle");
 		this.manager.emit("debug", `[QUEUE] userBlockShuffled the queue for: ${this.guild}`);
 	}
 
@@ -216,7 +216,7 @@ export class Queue extends Array<Track | UnresolvedTrack> {
 
 		this.splice(0);
 		this.add(shuffledQueue);
-		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueChange");
+		this.manager.emit("playerStateUpdate", oldPlayer, this.manager.players.get(this.guild), "queueRobinShuffle");
 		this.manager.emit("debug", `[QUEUE] roundRobinShuffled the queue for: ${this.guild}`);
 	}
 }


### PR DESCRIPTION
**Hi, in my bot I needed these things therefore I thought that others may also be useful:**

- The exact reasons in the event PlayerStateUpdate so I thought it would also be useful to everyone. Now it will be easier to locate what exactly caused the PlayerStateUpdate event, because I corrected the content of the reasons.
- More information about the playlist when it is searched using Manager.search() function:

**For example, this is what the response from the Manager.search() function looks like:**
Previously: 
```
{
   name: "Playlist name",
   tracks: [Object with tracks],
   duration: 3764634
}
```

Now: 
```
{
   name: "Playlist name",
   requester: [Object with requester user from discord],
   playlistInfo: {
      url: "url to playlist"
      type: "playlist".
      artworkUrl: "url to artwork"
      totalTracks: 40,
      author: "Playlist author"
   }
   tracks: [Object with tracks],
   duration: 3764634
}
```