### PR TITLE
2.8.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "magmastream",
-	"version": "2.8.6",
+	"version": "2.8.7-0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magmastream",
-			"version": "2.8.6",
+			"version": "2.8.7-0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "magmastream",
-	"version": "2.8.7-0",
+	"version": "2.8.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magmastream",
-			"version": "2.8.7-0",
+			"version": "2.8.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "magmastream",
-	"version": "2.8.6",
+	"version": "2.8.7-0",
 	"description": "A user-friendly Lavalink client designed for NodeJS.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "magmastream",
-	"version": "2.8.7-0",
+	"version": "2.8.7",
 	"description": "A user-friendly Lavalink client designed for NodeJS.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -1026,7 +1026,7 @@ export interface ManagerOptions {
 	/** The last.fm API key.
 	 * If you need to create one go here: https://www.last.fm/api/account/create.
 	 * If you already have one, get it from here: https://www.last.fm/api/accounts. */
-	lastFmApiKey: string;
+	lastFmApiKey?: string;
 	/** The maximum number of previous tracks to store. */
 	maxPreviousTracks?: number;
 	/** The array of nodes to connect to. */


### PR DESCRIPTION
- fixed lastFmApiKey not being optional but required in 2.8.6 as mentioned in https://github.com/Magmastream-NPM/magmastream/issues/473